### PR TITLE
Add feature: service account impersonation

### DIFF
--- a/lib/google_drive/collection.rb
+++ b/lib/google_drive/collection.rb
@@ -191,11 +191,12 @@ module GoogleDrive
 
     def files_with_type(type, params = {}, &block)
       params = convert_params(params)
-      query  = construct_and_query([
-                                     ['? in parents', id],
-                                     type ? ['mimeType = ?', type] : nil,
-                                     params[:q]
-                                   ])
+      query_arguments = [
+        type ? ['mimeType = ?', type] : nil,
+        params[:q]
+      ]
+      query_arguments.prepend ['? in parents', id] if (defined? id)
+      query  = construct_and_query(query_arguments)
       params = params.merge(q: query)
       # This is faster than calling children.list and then files.get for each
       # file.


### PR DESCRIPTION
This gem relies on an extant root folder for most of its operations. However, no root folder is found when impersonating an account. Therefore, in the impersonation case, use a dummy root folder.

Documentation for the `sub` call can be found at https://github.com/googleapis/google-api-ruby-client/blob/master/docs/oauth-server.md.
